### PR TITLE
Return a new instance of the Transformer every time the createTransformer method is called

### DIFF
--- a/versioned-assets/src/main/java/io/marto/aem/vassets/impl/AssetVersionTransformerFactory.java
+++ b/versioned-assets/src/main/java/io/marto/aem/vassets/impl/AssetVersionTransformerFactory.java
@@ -22,7 +22,6 @@ import io.marto.aem.vassets.servlet.RequestContext;
     @Property(name = "pipeline.type", value = "asset-version-transformer", propertyPrivate = true),
 })
 public class AssetVersionTransformerFactory implements TransformerFactory {
-    private static final AssetVersionTransformer NULL_TRANSFORMER = new AssetVersionTransformer(null);
 
     @Reference
     private SlingSettingsService settings;
@@ -44,16 +43,16 @@ public class AssetVersionTransformerFactory implements TransformerFactory {
     @Override
     public AssetVersionTransformer createTransformer() {
         if (!enabled) {
-            return NULL_TRANSFORMER;
+            return new AssetVersionTransformer(null);
         }
         String reqPath = requestContext.getRequestedResourcePath();
         if (!startsWith(reqPath, "/content")) {
-            return NULL_TRANSFORMER;
+            return new AssetVersionTransformer(null);
         }
         Configuration config = vService.findConfigByContentPath(reqPath);
         if (config == null) {
             LOG.debug("Can't locate config for content path '{}'", reqPath);
-            return NULL_TRANSFORMER;
+            return new AssetVersionTransformer(null);
         }
         return new AssetVersionTransformer(config);
     }


### PR DESCRIPTION
The transformers organize a pipeline in AEM. The next transformer is referenced by the previous one. So it is important to recreate the transformer objects every time the createTransformer() method is called to not reference the outdated transformer objects.